### PR TITLE
Disable magstripe encoding

### DIFF
--- a/mabelcardprinter/MainForm.cs
+++ b/mabelcardprinter/MainForm.cs
@@ -24,7 +24,12 @@ namespace MabelCardPrinter
         public MainForm()
         {
             InitializeComponent();
+            initialisePrinterManager();
             blankCard = Properties.Resources.CM_Cardblank;
+
+        }
+
+        private void initialisePrinterManager() {
             manager = new PrinterManager();
 
             manager.Registered += manager_Registered;
@@ -96,7 +101,6 @@ namespace MabelCardPrinter
             manager.StartUp(Properties.Settings.Default.PrinterID,
                 Properties.Settings.Default.LocalPrinter,
                 Properties.Settings.Default.PrinterLocation);
-
 
             lblProgressText.Text = "";
             managerRunning = false;

--- a/mabelcardprinter/PrinterManager.cs
+++ b/mabelcardprinter/PrinterManager.cs
@@ -78,6 +78,7 @@ namespace MabelCardPrinter
         private String _currentRfidToken;
         private bool _requestRegister = false;
         private bool _running = false;
+        private bool _magEncodeEnabled = true;
 
         public event PrinterEventHandler Registered;
         public event PrinterEventHandler RegisterError;
@@ -300,6 +301,18 @@ namespace MabelCardPrinter
             _requestPrint = true;
         }
 
+        public void isMagEncodingEnabled() {
+            return this._magEncodeEnabled;
+        }
+
+        public void disableMagEncoding() {
+            _magEncodeEnabled = false
+        }
+
+        public void enableMagEncoding() {
+            _magEncodeEnabled = true;
+        }
+
         public int GetPrinterId()
         {
             return this.printer_id;
@@ -392,6 +405,7 @@ namespace MabelCardPrinter
         public PrinterManager()
         {
             _state = PrinterState.UNREGISTERED;
+            _magEncodeEnabled = Properties.Settings.Default.MagstripeEnabled;
  
             this.pages_printed = 0;
 
@@ -584,6 +598,11 @@ namespace MabelCardPrinter
 
                 case (PrinterState.ENCODING):
                     // we are encoding the card
+                    if (!_magEncodeEnabled) {
+                        // skip encoding entirely
+                        _state = PrinterState.PRINTING;
+                        break;
+                    }
                     if (_abortPressed)
                     {
                         EjectCard();


### PR DESCRIPTION
A few changes which mean the checkbox in the settings menu to disable magstripe encoding does actually change the flow of activities such that magstripe encoding is not performed on a Magicard printer